### PR TITLE
Add support for Beast Man Tribes

### DIFF
--- a/1.0/Patches/BeastTribes.xml
+++ b/1.0/Patches/BeastTribes.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <success>Always</success>
+    <mods>
+      <li>Beast Man Tribes</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/RecipeDef[@Name="CAN_CookMealBase"]/fixedIngredientFilter/thingDefs</xpath>
+          <value>
+            <li>Meat_BearMan</li>
+            <li>Meat_CamelMan</li>
+            <li>Meat_ElephantMan</li>
+            <li>Meat_ElkMan</li>
+            <li>Meat_FoxMan</li>
+            <li>Meat_GazelleMan</li>
+            <li>Meat_LynxMan</li>
+            <li>Meat_PigMan</li>
+            <li>Meat_RaccoonMan</li>
+            <li>Meat_WolfMan</li>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/RecipeDef[@Name="CAN_CookMealBase"]/defaultIngredientFilter/thingDefs</xpath>
+          <value>
+            <li>Meat_BearMan</li>
+            <li>Meat_CamelMan</li>
+            <li>Meat_ElephantMan</li>
+            <li>Meat_ElkMan</li>
+            <li>Meat_FoxMan</li>
+            <li>Meat_GazelleMan</li>
+            <li>Meat_LynxMan</li>
+            <li>Meat_PigMan</li>
+            <li>Meat_RaccoonMan</li>
+            <li>Meat_WolfMan</li>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/RecipeDef[@ParentName="CAN_CannibalCampfire" or @ParentName="CAN_CannibalStove" or @ParentName="CAN_CannibalButcher"]/ingredients/li/filter/thingDefs</xpath>
+          <value>
+            <li>Meat_BearMan</li>
+            <li>Meat_CamelMan</li>
+            <li>Meat_ElephantMan</li>
+            <li>Meat_ElkMan</li>
+            <li>Meat_FoxMan</li>
+            <li>Meat_GazelleMan</li>
+            <li>Meat_LynxMan</li>
+            <li>Meat_PigMan</li>
+            <li>Meat_RaccoonMan</li>
+            <li>Meat_WolfMan</li>
+          </value>
+        </li>
+      </operations>
+    </match>
+  </Operation>
+</Patch>

--- a/1.1/Patches/Aliens/BeastTribes.xml
+++ b/1.1/Patches/Aliens/BeastTribes.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <success>Always</success>
+    <mods>
+      <li>Beast Man Tribes</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/RecipeDef[@Name="CAN_CookMealBase"]/fixedIngredientFilter/thingDefs</xpath>
+          <value>
+            <li>Meat_BearMan</li>
+            <li>Meat_CamelMan</li>
+            <li>Meat_ElephantMan</li>
+            <li>Meat_ElkMan</li>
+            <li>Meat_FoxMan</li>
+            <li>Meat_GazelleMan</li>
+            <li>Meat_LynxMan</li>
+            <li>Meat_PigMan</li>
+            <li>Meat_RaccoonMan</li>
+            <li>Meat_WolfMan</li>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/RecipeDef[@Name="CAN_CookMealBase"]/defaultIngredientFilter/thingDefs</xpath>
+          <value>
+            <li>Meat_BearMan</li>
+            <li>Meat_CamelMan</li>
+            <li>Meat_ElephantMan</li>
+            <li>Meat_ElkMan</li>
+            <li>Meat_FoxMan</li>
+            <li>Meat_GazelleMan</li>
+            <li>Meat_LynxMan</li>
+            <li>Meat_PigMan</li>
+            <li>Meat_RaccoonMan</li>
+            <li>Meat_WolfMan</li>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/RecipeDef[@ParentName="CAN_CannibalCampfire" or @ParentName="CAN_CannibalStove" or @ParentName="CAN_CannibalButcher"]/ingredients/li/filter/thingDefs</xpath>
+          <value>
+            <li>Meat_BearMan</li>
+            <li>Meat_CamelMan</li>
+            <li>Meat_ElephantMan</li>
+            <li>Meat_ElkMan</li>
+            <li>Meat_FoxMan</li>
+            <li>Meat_GazelleMan</li>
+            <li>Meat_LynxMan</li>
+            <li>Meat_PigMan</li>
+            <li>Meat_RaccoonMan</li>
+            <li>Meat_WolfMan</li>
+          </value>
+        </li>
+      </operations>
+    </match>
+  </Operation>
+</Patch>

--- a/About/About.xml
+++ b/About/About.xml
@@ -35,6 +35,7 @@
     <li>goudaquiche.lighterthanfast</li>
     <li>Juvia.StarTrekRaces</li>
     <li>Solaris.FurnitureBase</li>
+    <li>Heymyteamrules.BeastManTribes</li>
   </loadAfter>
   <description>Adds cannibal and insect versions of all base meals.
 


### PR DESCRIPTION
This adds support for the beast race tribes (from [this mod](https://steamcommunity.com/sharedfiles/filedetails/?id=1119191638)) to the cannibal meal bills. I've done only rudimentary testing (loading a game and verifying they show up in the allowed ingredients lists), but I copied it from Argonians.xml, so it should all work.