### PR TITLE
Update Fantasy Goblins patch so it checks for the presence of the HAR…

### DIFF
--- a/1.4/Patches/Aliens/Goblins.xml
+++ b/1.4/Patches/Aliens/Goblins.xml
@@ -1,10 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Patch>
-  <Operation Class="PatchOperationFindMod">
-    <success>Always</success>
-    <mods>
-      <li>Fantasy Goblins Updated</li>
-    </mods>
+  <Operation Class="PatchOperationConditional">
+    <xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Fantasy_Goblin"]</xpath>
     <match Class="PatchOperationSequence">
       <operations>
         <li Class="PatchOperationAdd">

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # CannibalMeals
-
+
+
 ![Image](https://i.imgur.com/iCj5o7O.png)
 
   
@@ -25,7 +26,7 @@ Alien races supported (Thanks to @Cerrendel)
 
 -  https://steamcommunity.com/sharedfiles/filedetails/?id=959780399]Argonians of Blackmarsh
 -  https://steamcommunity.com/sharedfiles/filedetails/?id=1611790118]Ferian Race
--  https://steamcommunity.com/sharedfiles/filedetails/?id=1465072243]Fantasy Goblins
+-  https://steamcommunity.com/sharedfiles/filedetails/?id=2011680079]Fantasy Goblins Updated
 -  https://steamcommunity.com/sharedfiles/filedetails/?id=1400238872]Lord of the Rims - Dwarves
 -  https://steamcommunity.com/sharedfiles/filedetails/?id=1400234784]Lord of the Rims - Elves
 -  https://steamcommunity.com/sharedfiles/filedetails/?id=1400227853]Lord of the Rims - Hobbits


### PR DESCRIPTION
… race instead of the mod

The Fantasy Goblins Updated mod adds a xenotype instead of a HAR race if the player has Biotech active.

Also updated the readme so the link points to the updated version of Fantasy Goblins.